### PR TITLE
feat: enable in Eyevinn Open Source Cloud

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ USER node
 WORKDIR /app
 COPY --chown=node:node ["package.json", "package-lock.json*", "tsconfig*.json", "./"]
 COPY --chown=node:node ["src", "./src"]
-COPY docker-entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+COPY docker-entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 # Delete prepare script to avoid errors from husky
 RUN npm pkg delete scripts.prepare \
     && npm ci --omit=dev
-ENTRYPOINT [ "/entrypoint.sh" ]
+ENTRYPOINT [ "/app/entrypoint.sh" ]
 CMD [ "npm", "run", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@ FROM ${NODE_IMAGE}
 ENV NODE_ENV=production
 EXPOSE 8000
 RUN mkdir /app
+COPY ./docker-entrypoint.sh /app/entrypoint.sh
 RUN chown node:node /app
+RUN chmod +x /app/entrypoint.sh
 USER node
 WORKDIR /app
 COPY --chown=node:node ["package.json", "package-lock.json*", "tsconfig*.json", "./"]
 COPY --chown=node:node ["src", "./src"]
-COPY docker-entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
 # Delete prepare script to avoid errors from husky
 RUN npm pkg delete scripts.prepare \
     && npm ci --omit=dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,10 @@ USER node
 WORKDIR /app
 COPY --chown=node:node ["package.json", "package-lock.json*", "tsconfig*.json", "./"]
 COPY --chown=node:node ["src", "./src"]
+COPY docker-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 # Delete prepare script to avoid errors from husky
 RUN npm pkg delete scripts.prepare \
     && npm ci --omit=dev
+ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "npm", "run", "start" ]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ -z "$REDIS_URL" ]; then
+  export REDIS_URL="redis://127.0.0.1:6379"
+fi
+
+echo "Using Redis URL: $REDIS_URL"
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ -z "$REDIS_URL" ]; then
-  export REDIS_URL="redis://127.0.0.1:6379"
+  export REDIS_URL="redis://localhost:6379"
 fi
 
 echo "Using Redis URL: $REDIS_URL"

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,8 @@
 
 A Proxy put in fron of an ad server that dispatches transcoding and packaging of VAST creatives.
 
+[![Badge OSC](https://img.shields.io/badge/Evaluate-24243B?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iMTIiIGZpbGw9InVybCgjcGFpbnQwX2xpbmVhcl8yODIxXzMxNjcyKSIvPgo8Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSI3IiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjIiLz4KPGRlZnM%2BCjxsaW5lYXJHcmFkaWVudCBpZD0icGFpbnQwX2xpbmVhcl8yODIxXzMxNjcyIiB4MT0iMTIiIHkxPSIwIiB4Mj0iMTIiIHkyPSIyNCIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPgo8c3RvcCBzdG9wLWNvbG9yPSIjQzE4M0ZGIi8%2BCjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzREQzlGRiIvPgo8L2xpbmVhckdyYWRpZW50Pgo8L2RlZnM%2BCjwvc3ZnPgo%3D)](https://app.osaas.io/browse/eyevinn-ad-normalizer)
+
 The service accepts requests to the endpoint `api/v1/vast`, and returns a JSON array with the following structure:
 
 ```json


### PR DESCRIPTION
Hi,

With this Pull Request we want to give you the option to add a badge to your README to show that
your software is available as an open web service in [Eyevinn Open Source Cloud](wwww.osaas.io).
With Eyevinn Open Source Cloud we turn open source into open web services and share the revenue
with the creators. 

Our goal with this platform is to reduce the barrier to get started with open source and contribute
to a sustainable business for open source by giving back a share of the revenue to the creators.
For our customers we can offer full code transparency and no vendor lock-in as all web services
are open source.

We want to *not be evil* and we do this to provide the creators with an additional
income stream for their projects.

Our pledge to the community is to:

 - §1. Share revenue that is generated by an open source project with the creator.
 - §2. Ensure that any modifications made to a project are available to the public 
       as a public fork.
 - §3. Never, ever, take open source code and turn it into closed source.
 - §4. Always provide our customers with the option to self-host the very same code 
       and never lock in to our platform or the underlying infrastructure.
 - §5. Remove the project from our platform if requested by the creator.

To claim ownership and receive a revenue share follow the instructions in 
the [documentation for creators](https://docs.osaas.io/osaas.wiki/Creator.html).

Jonas Birme
CTO Eyevinn Open Source Cloud