### PR TITLE
feat(#4): rewrite VAST XML if requested XML response type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@dailymotion/vast-client": "^6.0.2",
+        "@fastify/accepts-serializer": "^5.3.0",
         "@fastify/cors": "^8.2.0",
         "@fastify/swagger": "^8.3.1",
         "@fastify/swagger-ui": "^1.5.0",
@@ -995,6 +996,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@fastify/accepts": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/accepts/-/accepts-4.3.0.tgz",
+      "integrity": "sha512-QK4FoqXdwwPmaPOLL6NrxsyaXVvdviYVoS6ltHyOLdFlUyREIaMykHQIp+x0aJz9hB3B3n/Ht6QRdvBeGkptGQ==",
+      "dependencies": {
+        "accepts": "^1.3.5",
+        "fastify-plugin": "^4.0.0"
+      }
+    },
+    "node_modules/@fastify/accepts-serializer": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fastify/accepts-serializer/-/accepts-serializer-5.3.0.tgz",
+      "integrity": "sha512-DjFysJ/0GH13i9c371wrbYvE3A1VeSwwD5Jx7/nfHTsDUN4RpYaVqZsj18fAtEPbURcZtlNjM6ebC78NUdoi/g==",
+      "dependencies": {
+        "@fastify/accepts": "^4.0.0",
+        "fastify-plugin": "^4.0.0"
       }
     },
     "node_modules/@fastify/ajv-compiler": {
@@ -2247,6 +2266,18 @@
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
       "license": "MIT"
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/acorn": {
       "version": "8.14.0",
@@ -6431,6 +6462,14 @@
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@dailymotion/vast-client": "^6.0.2",
+    "@fastify/accepts-serializer": "^5.3.0",
     "@fastify/cors": "^8.2.0",
     "@fastify/swagger": "^8.3.1",
     "@fastify/swagger-ui": "^1.5.0",

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,10 @@ A Proxy put in fron of an ad server that dispatches transcoding and packaging of
 
 The service accepts requests to the endpoint `api/v1/vast`, and returns a JSON array with the following structure:
 
+```
+% curl -v "http://localhost:8000/api/v1/vast?dur=30"
+```
+
 ```json
 {
   "assets": [
@@ -13,8 +17,15 @@ The service accepts requests to the endpoint `api/v1/vast`, and returns a JSON a
       "creativeId": "abcd1234",
       "masterPlaylistUrl": "https://your-minio-endpoint/creativeId/substring/index.m3u8"
     }
-  ]
+  ],
+  "vastXml": "<VAST...>"
 }
+```
+
+or modified VAST XML if `application/xml` content-type is requested:
+
+```
+% curl -v -H 'accept: application/xml' "http://localhost:8000/api/v1/vast?dur=30"
 ```
 
 The service uses redis to keep track of transcoded creatives, and returns the master playlist URL if one is found; if the service does not know of any packaged assets for a creative, it creates a transcoding and packaging pipeline, and monitors the provided minio bucket for asset uploads. Once the assets are in place, the master playlist URL is added to the redis cache.

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -14,7 +14,15 @@ let config: AdNormalizerConfiguration | null = null;
 
 const loadConfiguration = (): AdNormalizerConfiguration => {
   const encoreUrl = process.env.ENCORE_URL;
-  const callbackListenerUrl = process.env.CALLBACK_LISTENER_URL;
+  if (!process.env.CALLBACK_LISTENER_URL) {
+    throw new Error('CALLBACK_LISTENER_URL is required');
+  }
+  // Handle whether CALLBACK_LISTENER_URL contains /encoreCallback
+  // or not
+  const callbackListenerUrl = new URL(
+    '/encoreCallback',
+    process.env.CALLBACK_LISTENER_URL
+  );
   const endpoint = process.env.S3_ENDPOINT;
   const accessKey = process.env.S3_ACCESS_KEY;
   const secretKey = process.env.S3_SECRET_KEY;
@@ -31,7 +39,7 @@ const loadConfiguration = (): AdNormalizerConfiguration => {
   const oscToken = process.env.OSC_ACCESS_TOKEN;
   const configuration = {
     encoreUrl: encoreUrl,
-    callbackListenerUrl: callbackListenerUrl,
+    callbackListenerUrl: callbackListenerUrl.toString(),
     s3Endpoint: endpoint,
     s3AccessKey: accessKey,
     s3SecretKey: secretKey,


### PR DESCRIPTION
This PR adds the original VAST XML as received from the adserver in the JSON response. If a client requests to receive XML instead a rewritten (proxied) VAST XML is returned. This will replace creative media files with the "normalized" ones if matched.

Also fixed so AD_SERVER_URL should contain the pathname as it cannot be assumed to be the same for all ad servers. This means that the AD_SERVER_URL=https://testadserver/api/v1/vast