### PR TITLE
feat: support for HLS interstitial asset lists

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ A Proxy put in fron of an ad server that dispatches transcoding and packaging of
 
 [![Badge OSC](https://img.shields.io/badge/Evaluate-24243B?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iMTIiIGZpbGw9InVybCgjcGFpbnQwX2xpbmVhcl8yODIxXzMxNjcyKSIvPgo8Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSI3IiBzdHJva2U9ImJsYWNrIiBzdHJva2Utd2lkdGg9IjIiLz4KPGRlZnM%2BCjxsaW5lYXJHcmFkaWVudCBpZD0icGFpbnQwX2xpbmVhcl8yODIxXzMxNjcyIiB4MT0iMTIiIHkxPSIwIiB4Mj0iMTIiIHkyPSIyNCIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiPgo8c3RvcCBzdG9wLWNvbG9yPSIjQzE4M0ZGIi8%2BCjxzdG9wIG9mZnNldD0iMSIgc3RvcC1jb2xvcj0iIzREQzlGRiIvPgo8L2xpbmVhckdyYWRpZW50Pgo8L2RlZnM%2BCjwvc3ZnPgo%3D)](https://app.osaas.io/browse/eyevinn-ad-normalizer)
 
-The service accepts requests to the endpoint `api/v1/vast`, and returns a JSON array with the following structure:
+The service accepts requests to the endpoint `api/v1/vast`, and returns a JSON array with the following structure if no conent type is requested:
 
 ```
 % curl -v "http://localhost:8000/api/v1/vast?dur=30"
@@ -26,6 +26,23 @@ or modified VAST XML if `application/xml` content-type is requested:
 
 ```
 % curl -v -H 'accept: application/xml' "http://localhost:8000/api/v1/vast?dur=30"
+```
+
+if `application/json` content-type is explicitly requested, the normalizer returns JSON conforming to the asset list standard used for HLS interstitials:
+
+```
+% curl -v -H 'accept: application/json' "http://localhost:8000/api/v1/vast?dur=30"
+```
+results in:
+```json
+{
+  "ASSETS": [
+    {
+      "DURATION": "30",
+      "URI": "https://your-minio-endpoint/creativeId/substring/index.m3u8"
+    }
+  ]
+}
 ```
 
 The service uses redis to keep track of transcoded creatives, and returns the master playlist URL if one is found; if the service does not know of any packaged assets for a creative, it creates a transcoding and packaging pipeline, and monitors the provided minio bucket for asset uploads. Once the assets are in place, the master playlist URL is added to the redis cache.

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,9 @@ if `application/json` content-type is explicitly requested, the normalizer retur
 ```
 % curl -v -H 'accept: application/json' "http://localhost:8000/api/v1/vast?dur=30"
 ```
+
 results in:
+
 ```json
 {
   "ASSETS": [

--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -1,0 +1,4 @@
+export const timestampToSeconds = (timestamp: string): number => {
+  const [hours, minutes, seconds] = timestamp.split(':').map(Number);
+  return hours * 3600 + minutes * 60 + seconds;
+};

--- a/src/util/utils.test.ts
+++ b/src/util/utils.test.ts
@@ -1,0 +1,21 @@
+import { timestampToSeconds } from './time';
+
+describe('time utils', () => {
+  it('deserializes timestamps correctly', () => {
+    let timestamp = '00:00:15';
+    let parsed = timestampToSeconds(timestamp);
+    expect(parsed).toBe(15);
+
+    timestamp = '00:01:00';
+    parsed = timestampToSeconds(timestamp);
+    expect(parsed).toBe(60);
+
+    timestamp = '01:00:00';
+    parsed = timestampToSeconds(timestamp);
+    expect(parsed).toBe(3600);
+
+    timestamp = '00:01:45';
+    parsed = timestampToSeconds(timestamp);
+    expect(parsed).toBe(105);
+  });
+});


### PR DESCRIPTION
When a client explicitly requests JSON by adding the header `accept: application/json`, the API responds with an asset list as defined by apple for HLS interstitials:
> The value of the X-ASSET-LIST is a quoted-string URL to a JSON object. The JSON object
must contain a key/value pair whose key is “ASSETS” and whose value is a JSON array of As-
set-Description JSON objects. (Note that keys in a JSON object are case-sensitive.) Each As-
set-Description JSON object MUST have a “URI” member whose value is a quoted-string abso-
lute URL for a single interstitial asset, and a DURATION member whose value is a decimal-float-
ing-point indicating the duration of the interstitial asset in seconds. The client is expected to
play the interstitial assets back-to-back in the order that they appear in the ASSETS array.

Other changes:
- Breaks out some logic from the api endpoint function for readability and reusability
- Adds utility function to parse time stamps

closes #7 