### PR TITLE
feat: use redis as lock to prevent assets being transcoded multiple times

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -11,6 +11,7 @@ export interface AdNormalizerConfiguration {
   adServerUrl: string;
   redisUrl: string;
   oscToken?: string;
+  inFlightTtl?: number;
 }
 
 let config: AdNormalizerConfiguration | null = null;
@@ -50,6 +51,7 @@ const loadConfiguration = (): AdNormalizerConfiguration => {
       ? path.join(bucket.hostname, bucket.pathname)
       : bucket.hostname;
   const oscToken = process.env.OSC_ACCESS_TOKEN;
+  const inFlightTtl = process.env.IN_FLIGHT_TTL;
   const configuration = {
     encoreUrl: removeTrailingSlash(encoreUrl.toString()),
     callbackListenerUrl: callbackListenerUrl.toString(),
@@ -59,7 +61,8 @@ const loadConfiguration = (): AdNormalizerConfiguration => {
     adServerUrl: adServerUrl,
     redisUrl: redisUrl,
     bucket: removeTrailingSlash(bucketPath),
-    oscToken: oscToken
+    oscToken: oscToken,
+    inFlightTtl: inFlightTtl ? parseInt(inFlightTtl) : null
   } as AdNormalizerConfiguration;
 
   return configuration;

--- a/src/redis/redisclient.ts
+++ b/src/redis/redisclient.ts
@@ -1,6 +1,9 @@
 import { createClient } from 'redis';
 import logger from '../util/logger';
 
+export const IN_PROGRESS = 'IN_PROGRESS';
+export const DEFAULT_TTL = 1800; // TTL of 30 minutes to account for queue time
+
 export class RedisClient {
   private client: Awaited<ReturnType<typeof createClient>> | null = null;
   constructor(private url: string) {}
@@ -31,9 +34,31 @@ export class RedisClient {
     return this.client?.get(key);
   }
 
-  async set(key: string, value: string): Promise<void> {
+  async set(key: string, value: string, ttl: number): Promise<void> {
     logger.info('Setting key', { key, value });
     await this.connect();
     this.client?.set(key, value);
+    await this.setTtl(key, ttl);
+  }
+
+  async setTtl(key: string, ttl: number): Promise<void> {
+    if (ttl > 0) {
+      logger.info('Setting key expiration', { key, ttl });
+      await this.client?.expire(key, ttl);
+    } else {
+      const expireTime = await this.client?.expireTime(key);
+      if (expireTime != undefined) {
+        switch (expireTime) {
+          case -1:
+            logger.info('Key has no expiration', { key });
+            break;
+          case -2:
+            logger.error('Key does not exist', { key });
+            break;
+          default:
+            await this.client?.persist(key);
+        }
+      }
+    }
   }
 }

--- a/src/vast/vastApi.ts
+++ b/src/vast/vastApi.ts
@@ -5,7 +5,7 @@ import fastifyAcceptsSerializer from '@fastify/accepts-serializer';
 import { XMLParser, XMLBuilder } from 'fast-xml-parser';
 import logger from '../util/logger';
 import { timestampToSeconds } from '../util/time';
-import { removeTrailingSlash } from '../util/string';
+import { IN_PROGRESS } from '../redis/redisclient';
 
 export const ManifestAsset = Type.Object({
   creativeId: Type.String(),
@@ -95,8 +95,13 @@ const partitionCreatives = async (
   for (const creative of creatives) {
     const asset = await lookUpAsset(creative.creativeId);
     logger.debug('Looking up asset', { creative, asset });
-    if (asset) {
-      found.push({ creativeId: creative.creativeId, masterPlaylistUrl: asset });
+    if (asset && asset) {
+      if (asset !== IN_PROGRESS) {
+        found.push({
+          creativeId: creative.creativeId,
+          masterPlaylistUrl: asset
+        });
+      }
     } else {
       missing.push({
         creativeId: creative.creativeId,


### PR DESCRIPTION
Uses the redis key that is looked up in `partitionCreatives()` as a distributed lock in order to avoid multiple transcoding jobs being requested for the same asset. The lock has a TTL that can be set using the `IN_FLIGHT_TTL` environment variable, and defaults to 30 minutes. When the normalizer receives a notification from minio, it replaces the value with the (relative) URL to the master playlist, and persists the key in redis.