### PR TITLE
fix: vmap interface and update tests

### DIFF
--- a/src/vmap/vmapApi.test.ts
+++ b/src/vmap/vmapApi.test.ts
@@ -358,25 +358,30 @@ describe('VMAP API', () => {
           'vmap:AdBreak': [
             {
               'vmap:AdSource': {
-                'vast:VAST': {
-                  Ad: {
-                    InLine: {
-                      Creatives: {
-                        Creative: {
-                          UniversalAdId: {
-                            '#text': 'ad123'
-                          },
-                          Linear: {
-                            MediaFiles: {
-                              MediaFile: {
-                                '#text': 'http://example.com/video.mp4',
-                                '@_bitrate': '2000'
+                'vmap:VASTAdData': {
+                  VAST: {
+                    Ad: [
+                      {
+                        InLine: {
+                          Creatives: {
+                            Creative: {
+                              UniversalAdId: {
+                                '#text': 'ad123'
+                              },
+                              Linear: {
+                                MediaFiles: {
+                                  MediaFile: {
+                                    '#text': 'http://example.com/video.mp4',
+                                    '@_bitrate': '2000',
+                                    '@_type': 'video/mp4'
+                                  }
+                                }
                               }
                             }
                           }
                         }
                       }
-                    }
+                    ]
                   }
                 }
               }
@@ -399,19 +404,22 @@ describe('VMAP API', () => {
           'vmap:AdBreak': [
             {
               'vmap:AdSource': {
-                'vast:VAST': {
-                  Ad: {
-                    InLine: {
-                      Creatives: {
-                        Creative: {
-                          UniversalAdId: {
-                            '#text': 'ad123'
-                          },
-                          Linear: {
-                            MediaFiles: {
-                              MediaFile: {
-                                '#text': 'http://example.com/video1.mp4',
-                                '@_bitrate': '2000'
+                'vmap:VASTAdData': {
+                  VAST: {
+                    Ad: {
+                      InLine: {
+                        Creatives: {
+                          Creative: {
+                            UniversalAdId: {
+                              '#text': 'ad123'
+                            },
+                            Linear: {
+                              MediaFiles: {
+                                MediaFile: {
+                                  '#text': 'http://example.com/video1.mp4',
+                                  '@_bitrate': '2000',
+                                  '@_type': 'video/mp4'
+                                }
                               }
                             }
                           }
@@ -424,19 +432,22 @@ describe('VMAP API', () => {
             },
             {
               'vmap:AdSource': {
-                'vast:VAST': {
-                  Ad: {
-                    InLine: {
-                      Creatives: {
-                        Creative: {
-                          UniversalAdId: {
-                            '#text': 'ad456'
-                          },
-                          Linear: {
-                            MediaFiles: {
-                              MediaFile: {
-                                '#text': 'http://example.com/video2.mp4',
-                                '@_bitrate': '2000'
+                'vmap:VASTAdData': {
+                  VAST: {
+                    Ad: {
+                      InLine: {
+                        Creatives: {
+                          Creative: {
+                            UniversalAdId: {
+                              '#text': 'ad456'
+                            },
+                            Linear: {
+                              MediaFiles: {
+                                MediaFile: {
+                                  '#text': 'http://example.com/video2.mp4',
+                                  '@_bitrate': '2000',
+                                  '@_type': 'video/mp4'
+                                }
                               }
                             }
                           }
@@ -469,47 +480,51 @@ describe('VMAP API', () => {
           'vmap:AdBreak': [
             {
               'vmap:AdSource': {
-                'vast:VAST': {
-                  Ad: [
-                    {
-                      InLine: {
-                        Creatives: {
-                          Creative: {
-                            UniversalAdId: {
-                              '#text': 'ad123'
-                            },
-                            Linear: {
-                              MediaFiles: {
-                                MediaFile: {
-                                  '#text': 'http://example.com/video1.mp4',
-                                  '@_bitrate': '2000'
+                'vmap:VASTAdData': {
+                  VAST: {
+                    Ad: [
+                      {
+                        InLine: {
+                          Creatives: {
+                            Creative: {
+                              UniversalAdId: {
+                                '#text': 'ad123'
+                              },
+                              Linear: {
+                                MediaFiles: {
+                                  MediaFile: {
+                                    '#text': 'http://example.com/video1.mp4',
+                                    '@_bitrate': '2000',
+                                    '@_type': 'video/mp4'
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        InLine: {
+                          Creatives: {
+                            Creative: {
+                              UniversalAdId: {
+                                '#text': 'ad456'
+                              },
+                              Linear: {
+                                MediaFiles: {
+                                  MediaFile: {
+                                    '#text': 'http://example.com/video2.mp4',
+                                    '@_bitrate': '2000',
+                                    '@_type': 'video/mp4'
+                                  }
                                 }
                               }
                             }
                           }
                         }
                       }
-                    },
-                    {
-                      InLine: {
-                        Creatives: {
-                          Creative: {
-                            UniversalAdId: {
-                              '#text': 'ad456'
-                            },
-                            Linear: {
-                              MediaFiles: {
-                                MediaFile: {
-                                  '#text': 'http://example.com/video2.mp4',
-                                  '@_bitrate': '2000'
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  ]
+                    ]
+                  }
                 }
               }
             }

--- a/src/vmap/vmapApi.ts
+++ b/src/vmap/vmapApi.ts
@@ -17,9 +17,16 @@ import logger from '../util/logger';
 import { IN_PROGRESS } from '../redis/redisclient';
 
 interface VmapAdBreak {
+  '@_breakId'?: string;
+  '@_breakType'?: string;
+  '@_timeOffset'?: string;
   'vmap:AdSource'?: {
-    'vast:VAST'?: {
-      Ad?: VastAd | VastAd[];
+    '@_id'?: string;
+    'vmap:VASTAdData'?: {
+      VAST: {
+        '@_version'?: string;
+        Ad: VastAd | VastAd[];
+      };
     };
   };
 }
@@ -221,12 +228,12 @@ export const getCreatives = async (
     const creatives: ManifestAsset[] = [];
     if (vmapXml['vmap:VMAP']['vmap:AdBreak']) {
       for (const adBreak of vmapXml['vmap:VMAP']['vmap:AdBreak']) {
-        if (adBreak['vmap:AdSource']?.['vast:VAST']?.Ad) {
+        if (adBreak['vmap:AdSource']?.['vmap:VASTAdData']?.['VAST']?.Ad) {
           const vastAds = Array.isArray(
-            adBreak['vmap:AdSource']['vast:VAST'].Ad
+            adBreak['vmap:AdSource']['vmap:VASTAdData']['VAST'].Ad
           )
-            ? adBreak['vmap:AdSource']['vast:VAST'].Ad
-            : [adBreak['vmap:AdSource']['vast:VAST'].Ad];
+            ? adBreak['vmap:AdSource']['vmap:VASTAdData']['VAST'].Ad
+            : [adBreak['vmap:AdSource']['vmap:VASTAdData']['VAST'].Ad];
 
           for (const vastAd of vastAds) {
             const adId = vastAd.InLine.Creatives.Creative.UniversalAdId[


### PR DESCRIPTION
PR has a quick fix for an issue with the VMAP interface. Field `vmap:VASTAdData` was missing. 

Vmap interface, getCreatives(), and unit tests for getCreatives() are corrected