### PR TITLE
feat: configurable encore profile

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -73,6 +73,7 @@ export default (opts: ApiOptions) => {
   const encoreClient = new EncoreClient(
     config.encoreUrl,
     config.callbackListenerUrl,
+    config.encoreProfile,
     config.oscToken
   );
 

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -13,6 +13,7 @@ describe('config loading behavior', () => {
     process.env.OSC_ACCESS_TOKEN = 'token';
     process.env.KEY_FIELD = 'Url';
     process.env.KEY_REGEX = '[a-zA-Z]';
+    process.env.ENCORE_PROFILE = 'test-profile';
 
     const config = getConfiguration();
     const expectedBucketName = 'ads';
@@ -22,5 +23,6 @@ describe('config loading behavior', () => {
     expect(config.encoreUrl).toEqual(expectedEncoreUrl);
     expect(config.keyRegex).toEqual('[a-zA-Z]');
     expect(config.keyField).toEqual('url');
+    expect(config.encoreProfile).toEqual('test-profile');
   });
 });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -14,6 +14,7 @@ export interface AdNormalizerConfiguration {
   inFlightTtl?: number;
   keyField: string;
   keyRegex: string;
+  encoreProfile: string;
 }
 
 let config: AdNormalizerConfiguration | null = null;
@@ -58,6 +59,8 @@ const loadConfiguration = (): AdNormalizerConfiguration => {
   const keyField = process.env.KEY_FIELD;
   const keyRegex = process.env.KEY_REGEX;
 
+  const encoreProfile = process.env.ENCORE_PROFILE;
+
   const configuration = {
     encoreUrl: removeTrailingSlash(encoreUrl.toString()),
     callbackListenerUrl: callbackListenerUrl.toString(),
@@ -70,7 +73,8 @@ const loadConfiguration = (): AdNormalizerConfiguration => {
     oscToken: oscToken,
     inFlightTtl: inFlightTtl ? parseInt(inFlightTtl) : null,
     keyField: keyField ? keyField.toLowerCase() : 'UniversalAdId'.toLowerCase(),
-    keyRegex: keyRegex ? keyRegex : '[^a-zA-Z0-9]'
+    keyRegex: keyRegex ? keyRegex : '[^a-zA-Z0-9]',
+    encoreProfile: encoreProfile ? encoreProfile : 'program'
   } as AdNormalizerConfiguration;
 
   return configuration;

--- a/src/encore/encoreclient.test.ts
+++ b/src/encore/encoreclient.test.ts
@@ -56,7 +56,7 @@ describe('EncoreClient', () => {
   });
 
   it('Should not append access token if none is provided', async () => {
-    encoreClient = new EncoreClient(url, callbackUrl);
+    encoreClient = new EncoreClient(url, callbackUrl, 'test-profile');
     const job: EncoreJob = {
       externalId: '123',
       profile: 'program',

--- a/src/encore/encoreclient.ts
+++ b/src/encore/encoreclient.ts
@@ -7,6 +7,7 @@ export class EncoreClient {
   constructor(
     private url: string,
     private callbackUrl: string,
+    private profile: string,
     private oscToken?: string
   ) {}
 
@@ -38,7 +39,7 @@ export class EncoreClient {
     }
     const job: EncoreJob = {
       externalId: creative.creativeId,
-      profile: 'program',
+      profile: this.profile,
       outputFolder: '/usercontent/',
       baseName: creative.creativeId,
       progressCallbackUri: this.callbackUrl,


### PR DESCRIPTION
Adds the ability to control which transcoding profile the ad normalizer will tell encore to use, based on the environment variable `ENCORE_PROFILE`. If this is not set, it defaults to `'program'`.
Signed-off-by: Fredrik Lundkvist <fredrik.lundkvist@eyevinn.se>
