### PR TITLE
fix: dangling promise in redis client

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import { removeTrailingSlash } from '../util/string';
-import logger from '../util/logger';
 
 export interface AdNormalizerConfiguration {
   encoreUrl: string;

--- a/src/redis/redisclient.ts
+++ b/src/redis/redisclient.ts
@@ -93,7 +93,7 @@ export class RedisClient {
       return;
     }
     // Null check below needs to be handled way better
-    this.client?.zAdd(this.packagingQueueName, {
+    await this.client?.zAdd(this.packagingQueueName, {
       score: Date.now(),
       value: stringifiedJob
     });


### PR DESCRIPTION
- Fix an issue where we don't await the resolution of `zAdd` in `enqueuePackagingJob`, resulting in a dangling promise.
Signed-off-by: Fredrik Lundkvist <fredrik.lundkvist@eyevinn.se>
