### PR TITLE
fix: keep redis collection alive

### DIFF
--- a/src/encore/encoreclient.ts
+++ b/src/encore/encoreclient.ts
@@ -41,7 +41,7 @@ export class EncoreClient {
 
   async getEncoreJob(
     jobId: string,
-    serviceAccessToken?: string // TODO: Add the SAT when needed
+    serviceAccessToken?: string
   ): Promise<EncoreJob> {
     const contentHeaders = {
       'Content-Type': 'application/json',
@@ -53,6 +53,7 @@ export class EncoreClient {
       headers: { ...contentHeaders, ...jwtHeader }
     });
     if (!response.ok) {
+      logger.error(`Failed to get encore job: ${response.statusText}`);
       throw new Error(`Failed to get encore job: ${response.statusText}`);
     }
     return (await response.json()) as EncoreJob;

--- a/src/encore/encoreservice.ts
+++ b/src/encore/encoreservice.ts
@@ -91,26 +91,35 @@ export class EncoreService {
 
   transcodeInfoFromEncoreJob(job: EncoreJob): TranscodeInfo {
     const jobStatus = this.getTranscodeStatus(job);
-    const firstVideoStream = job.output?.reduce(
-      (videoStreams: VideoStream[], output) => {
-        return output.videoStreams
-          ? [...videoStreams, ...output.videoStreams]
-          : videoStreams;
-      },
-      []
-    )[0];
-    const aspectRatio = calculateAspectRatio(
-      firstVideoStream?.height || 1920,
-      firstVideoStream?.width || 1080
-    ); // fallback to 16:9
-    return {
-      url: this.jitPackaging
-        ? createPackageUrl(this.assetServerUrl, job.outputFolder, job.baseName)
-        : '', // If packaging is not JIT, we shouldn't set URL here
-      aspectRatio: aspectRatio,
-      framerates: this.getFrameRates(job),
-      status: jobStatus
-    };
+    try {
+      const firstVideoStream = job.output?.reduce(
+        (videoStreams: VideoStream[], output) => {
+          return output.videoStreams
+            ? [...videoStreams, ...output.videoStreams]
+            : videoStreams;
+        },
+        []
+      )[0];
+      const aspectRatio = calculateAspectRatio(
+        firstVideoStream?.height || 1920,
+        firstVideoStream?.width || 1080
+      ); // fallback to 16:9
+      return {
+        url: this.jitPackaging
+          ? createPackageUrl(
+              this.assetServerUrl,
+              job.outputFolder,
+              job.baseName
+            )
+          : '', // If packaging is not JIT, we shouldn't set URL here
+        aspectRatio: aspectRatio,
+        framerates: this.getFrameRates(job),
+        status: jobStatus
+      };
+    } catch (e) {
+      logger.error('Error creating transcode info', e);
+      throw new Error('Error creating transcode info');
+    }
   }
 
   getTranscodeStatus(job: EncoreJob): TranscodeStatus {

--- a/src/redis/redisclient.test.ts
+++ b/src/redis/redisclient.test.ts
@@ -40,7 +40,10 @@ describe('RedisClient', () => {
 
   it('should connect to Redis', async () => {
     await redisClient.connect();
-    expect(createClient).toHaveBeenCalledWith({ url: mockUrl });
+    expect(createClient).toHaveBeenCalledWith({
+      url: mockUrl,
+      socket: { keepAlive: 1, reconnectStrategy: 1000 }
+    });
     expect(logger.info).toHaveBeenCalledWith('Connecting to Redis', {
       url: mockUrl
     });

--- a/src/redis/redisclient.ts
+++ b/src/redis/redisclient.ts
@@ -15,8 +15,14 @@ export class RedisClient {
       return;
     }
     logger.info('Connecting to Redis', { url: this.url });
-    this.client = await createClient({ url: this.url })
-      .on('error', (err) => logger.error('Redis error', err))
+    this.client = await createClient({
+      url: this.url,
+      socket: {
+        keepAlive: 1,
+        reconnectStrategy: 1000
+      }
+    })
+      .on('error', (err) => logger.error('Redis error:', err))
       .connect();
     return;
   }


### PR DESCRIPTION
- Add keepalive  to redis client
- Add reconnect strategy on dropped connection, wait 1 second then retry.
- Add error logging and try/catch for encore interactions that happen on job completion to try and diagnose errors observed in OSC
Signed-off-by: Fredrik Lundkvist <fredrik.lundkvist@eyevinn.se>
