### PR TITLE
fix: add ping interval to redis client

### DIFF
--- a/src/encore/encoreclient.ts
+++ b/src/encore/encoreclient.ts
@@ -1,4 +1,3 @@
-import { Encore } from '@osaas/client-services';
 import logger from '../util/logger';
 import { EncoreJob } from './types';
 import { Context } from '@osaas/client-core';

--- a/src/redis/redisclient.test.ts
+++ b/src/redis/redisclient.test.ts
@@ -42,7 +42,8 @@ describe('RedisClient', () => {
     await redisClient.connect();
     expect(createClient).toHaveBeenCalledWith({
       url: mockUrl,
-      socket: { keepAlive: 1, reconnectStrategy: 1000 }
+      socket: { reconnectStrategy: 1000 },
+      pingInterval: 3000
     });
     expect(logger.info).toHaveBeenCalledWith('Connecting to Redis', {
       url: mockUrl

--- a/src/redis/redisclient.ts
+++ b/src/redis/redisclient.ts
@@ -18,9 +18,9 @@ export class RedisClient {
     this.client = await createClient({
       url: this.url,
       socket: {
-        keepAlive: 1,
         reconnectStrategy: 1000
-      }
+      },
+      pingInterval: 3000
     })
       .on('error', (err) => logger.error('Redis error:', err))
       .connect();


### PR DESCRIPTION
Since the `socket.keepAlive` setting did not fix the constant "socket closed unexpectedly" errors, we can try a different approach. By setting a ping interval, we might be able to keep the client connection alive.
Signed-off-by: Fredrik Lundkvist <fredrik.lundkvist@eyevinn.se>
