### PR TITLE
fix: output path from packaging callback body

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -118,6 +118,7 @@ Note: the ad normalizer assumes that your packager is set up with the output sub
 | `KEY_FIELD`             | The VAST field used as key in the cache. possible non-default values are `resolution` and `url`. If no value is provided, it used the universal Ad Id | universalAdId  | no        |
 | `KEY_REGEX`             | RegExp string used to strip away unwanted characters from the key string                                                                              | `[^a-zA-Z0-9]` | no        |
 | `ENCORE_PROFILE`        | The transcoding profile used by encore when processing the ads                                                                                        | program        | no        |
+| `ASSET_SERVER_URL`      | Base URL used in the links created for manifests. Typical use case is a CDN URL. If not set, a https version of output bucket URL is used             | none           | no        |
 
 ### starting the service
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -106,7 +106,9 @@ export default (opts: ApiOptions) => {
   const packagingService = new PackagingService(
     redisclient,
     encoreClient,
-    `https://${config.s3Endpoint}/${config.bucket}/`,
+    config.assetServerUrl
+      ? config.assetServerUrl
+      : `https://${config.s3Endpoint}/${config.bucket}/`,
     config.inFlightTtl ? config.inFlightTtl : DEFAULT_TTL
   );
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -19,6 +19,7 @@ export interface AdNormalizerConfiguration {
   packagingQueueName?: string;
   rootUrl: string;
   bucketUrl: URL;
+  assetServerUrl?: string;
 }
 
 let config: AdNormalizerConfiguration | null = null;
@@ -91,7 +92,8 @@ const loadConfiguration = (): AdNormalizerConfiguration => {
     jitPackaging: jitPackaging,
     packagingQueueName: packagingQueueName,
     rootUrl: rootUrl,
-    bucketUrl: bucket
+    bucketUrl: bucket,
+    assetServerUrl: process.env.ASSET_SERVER_URL
   } as AdNormalizerConfiguration;
 
   return configuration;

--- a/src/packaging/packagingservice.test.ts
+++ b/src/packaging/packagingservice.test.ts
@@ -78,13 +78,14 @@ describe('packaging service', () => {
     } as EncoreJob);
     const progress: PackagingSuccessBody = {
       jobId: 'test-job-id',
-      url: 'https://encore-instance'
+      url: 'https://encore-instance',
+      outputPath: '/output-folder/assetId/jobId/'
     };
     await packagingService.handlePackagingCompleted(progress);
     expect(redisClient.get).toHaveBeenCalledWith('test-external-id');
     const expectedTcInfo: TranscodeInfo = {
       ...tcInfo,
-      url: 'http://asset-server-url/output-folder/base-name.m3u8',
+      url: 'http://asset-server-url/output-folder/assetId/jobId/index.m3u8',
       status: TranscodeStatus.COMPLETED
     };
     expect(redisClient.saveTranscodeStatus).toHaveBeenCalledWith(

--- a/src/packaging/packagingservice.ts
+++ b/src/packaging/packagingservice.ts
@@ -8,6 +8,7 @@ import { createPackageUrl } from '../util/string';
 export type PackagingSuccessBody = {
   url: string;
   jobId: string;
+  outputPath: string;
 };
 
 export type PackagingFailureBody = {
@@ -53,8 +54,8 @@ export class PackagingService {
     const transcodeInfo = JSON.parse(job) as TranscodeInfo;
     const packageUrl = createPackageUrl(
       this.assetServerUrl,
-      encoreJob.outputFolder,
-      encoreJob.baseName
+      success.outputPath,
+      'index'
     );
     transcodeInfo.url = packageUrl;
     transcodeInfo.status = TranscodeStatus.COMPLETED;


### PR DESCRIPTION
At the moment, the normalizer has to guess where the packaged assets are.
There's a PR in the packager: https://github.com/Eyevinn/encore-packager/pull/14 to send the output path as part of a job success callback; the normalizer gets updated use this path to create the URLs.
Signed-off-by: Fredrik Lundkvist <fredrik.lundkvist@eyevinn.se>
