### PR TITLE
feat: pass along forwaded-for value

### DIFF
--- a/src/vmap/vmapApi.test.ts
+++ b/src/vmap/vmapApi.test.ts
@@ -690,5 +690,20 @@ describe('VMAP API', () => {
         method: 'GET'
       });
     });
+    it('should pass along forwarded for header', async () => {
+      getVmapXml('http://ad-server-url/api', '/path/to/vmap?param=value', {
+        'X-Forwarded-For': 'test-ip'
+      });
+      const expectedUrl = new URL('http://ad-server-url/api');
+      expectedUrl.searchParams.append('param', 'value');
+      expectedUrl.searchParams.append('rt', 'vmap');
+      expect(fetchMock).toHaveBeenCalledWith(expectedUrl, {
+        headers: {
+          'Content-Type': 'application/xml',
+          'X-Forwarded-For': 'test-ip'
+        },
+        method: 'GET'
+      });
+    });
   });
 });


### PR DESCRIPTION
If the header `X-Forwarded-For` is present in a request, it is passed along to the Ad server.
Fix incorrect header name for device user agent in the vmap endpoint
closes #46
Signed-off-by: Fredrik Lundkvist <fredrik.lundkvist@eyevinn.se>
