### PR TITLE
fix: header keys should be lowercase

### DIFF
--- a/src/vast/vastApi.ts
+++ b/src/vast/vastApi.ts
@@ -165,8 +165,8 @@ export const vastApi: FastifyPluginCallback<AdApiOptions> = (
       const path = req.url;
       const headers = req.headers;
       let vastReqHeaders = {};
-      const deviceUserAgent = getHeaderValue(headers, deviceUserAgentHeader);
-      const forwardedFor = getHeaderValue(headers, 'X-Forwarded-For');
+      const deviceUserAgent = getHeaderValue(headers, deviceUserAgentHeader.toLowerCase());
+      const forwardedFor = getHeaderValue(headers, 'X-Forwarded-For'.toLowerCase());
       if (deviceUserAgent) {
         vastReqHeaders = {
           ...vastReqHeaders,

--- a/src/vast/vastApi.ts
+++ b/src/vast/vastApi.ts
@@ -165,8 +165,14 @@ export const vastApi: FastifyPluginCallback<AdApiOptions> = (
       const path = req.url;
       const headers = req.headers;
       let vastReqHeaders = {};
-      const deviceUserAgent = getHeaderValue(headers, deviceUserAgentHeader.toLowerCase());
-      const forwardedFor = getHeaderValue(headers, 'X-Forwarded-For'.toLowerCase());
+      const deviceUserAgent = getHeaderValue(
+        headers,
+        deviceUserAgentHeader.toLowerCase()
+      );
+      const forwardedFor = getHeaderValue(
+        headers,
+        'X-Forwarded-For'.toLowerCase()
+      );
       if (deviceUserAgent) {
         vastReqHeaders = {
           ...vastReqHeaders,

--- a/src/vmap/vmapApi.ts
+++ b/src/vmap/vmapApi.ts
@@ -91,6 +91,7 @@ export const vmapApi: FastifyPluginCallback<AdApiOptions> = (
       const forwardedFor = getHeaderValue(headers, 'X-Forwarded-For');
       let vmapReqHeaders = {};
       if (deviceUserAgent) {
+        logger.debug('Device user agent header', { deviceUserAgent });
         vmapReqHeaders = {
           ...vmapReqHeaders,
           [deviceUserAgentHeader]: deviceUserAgent
@@ -99,6 +100,7 @@ export const vmapApi: FastifyPluginCallback<AdApiOptions> = (
         logger.error('Missing device user agent header');
       }
       if (forwardedFor) {
+        logger.debug('X-Forwarded-For header', { forwardedFor });
         vmapReqHeaders = { ...vmapReqHeaders, 'X-Forwarded-For': forwardedFor };
       } else {
         logger.error('Missing X-Forwarded-For header');

--- a/src/vmap/vmapApi.ts
+++ b/src/vmap/vmapApi.ts
@@ -87,8 +87,8 @@ export const vmapApi: FastifyPluginCallback<AdApiOptions> = (
     async (req, reply) => {
       const path = req.url;
       const headers = req.headers;
-      const deviceUserAgent = getHeaderValue(headers, deviceUserAgentHeader);
-      const forwardedFor = getHeaderValue(headers, 'X-Forwarded-For');
+      const deviceUserAgent = getHeaderValue(headers, deviceUserAgentHeader.toLowerCase());
+      const forwardedFor = getHeaderValue(headers, 'X-Forwarded-For'.toLowerCase());
       let vmapReqHeaders = {};
       if (deviceUserAgent) {
         logger.info('Device user agent header', { deviceUserAgent });

--- a/src/vmap/vmapApi.ts
+++ b/src/vmap/vmapApi.ts
@@ -91,7 +91,7 @@ export const vmapApi: FastifyPluginCallback<AdApiOptions> = (
       const forwardedFor = getHeaderValue(headers, 'X-Forwarded-For');
       let vmapReqHeaders = {};
       if (deviceUserAgent) {
-        logger.debug('Device user agent header', { deviceUserAgent });
+        logger.info('Device user agent header', { deviceUserAgent });
         vmapReqHeaders = {
           ...vmapReqHeaders,
           [deviceUserAgentHeader]: deviceUserAgent
@@ -100,7 +100,7 @@ export const vmapApi: FastifyPluginCallback<AdApiOptions> = (
         logger.error('Missing device user agent header');
       }
       if (forwardedFor) {
-        logger.debug('X-Forwarded-For header', { forwardedFor });
+        logger.info('X-Forwarded-For header', { forwardedFor });
         vmapReqHeaders = { ...vmapReqHeaders, 'X-Forwarded-For': forwardedFor };
       } else {
         logger.error('Missing X-Forwarded-For header');

--- a/src/vmap/vmapApi.ts
+++ b/src/vmap/vmapApi.ts
@@ -87,8 +87,14 @@ export const vmapApi: FastifyPluginCallback<AdApiOptions> = (
     async (req, reply) => {
       const path = req.url;
       const headers = req.headers;
-      const deviceUserAgent = getHeaderValue(headers, deviceUserAgentHeader.toLowerCase());
-      const forwardedFor = getHeaderValue(headers, 'X-Forwarded-For'.toLowerCase());
+      const deviceUserAgent = getHeaderValue(
+        headers,
+        deviceUserAgentHeader.toLowerCase()
+      );
+      const forwardedFor = getHeaderValue(
+        headers,
+        'X-Forwarded-For'.toLowerCase()
+      );
       let vmapReqHeaders = {};
       if (deviceUserAgent) {
         vmapReqHeaders = {

--- a/src/vmap/vmapApi.ts
+++ b/src/vmap/vmapApi.ts
@@ -91,7 +91,6 @@ export const vmapApi: FastifyPluginCallback<AdApiOptions> = (
       const forwardedFor = getHeaderValue(headers, 'X-Forwarded-For'.toLowerCase());
       let vmapReqHeaders = {};
       if (deviceUserAgent) {
-        logger.info('Device user agent header', { deviceUserAgent });
         vmapReqHeaders = {
           ...vmapReqHeaders,
           [deviceUserAgentHeader]: deviceUserAgent
@@ -100,7 +99,6 @@ export const vmapApi: FastifyPluginCallback<AdApiOptions> = (
         logger.error('Missing device user agent header');
       }
       if (forwardedFor) {
-        logger.info('X-Forwarded-For header', { forwardedFor });
         vmapReqHeaders = { ...vmapReqHeaders, 'X-Forwarded-For': forwardedFor };
       } else {
         logger.error('Missing X-Forwarded-For header');

--- a/src/vmap/vmapApi.ts
+++ b/src/vmap/vmapApi.ts
@@ -95,9 +95,13 @@ export const vmapApi: FastifyPluginCallback<AdApiOptions> = (
           ...vmapReqHeaders,
           [deviceUserAgentHeader]: deviceUserAgent
         };
+      } else {
+        logger.error('Missing device user agent header');
       }
       if (forwardedFor) {
         vmapReqHeaders = { ...vmapReqHeaders, 'X-Forwarded-For': forwardedFor };
+      } else {
+        logger.error('Missing X-Forwarded-For header');
       }
       const vmapStr = await getVmapXml(opts.adServerUrl, path, vmapReqHeaders);
       const vmapXml = parseVmap(vmapStr);


### PR DESCRIPTION
### the problem
Headers that are supposed to be passed on to the ad server (device user agent and forwarded for) didn't get propagated, due to the normalizer not realizing that the headers were present.

### the fix
Seems like fastify sets all header keys as lowercase. By transforming the key strings to lowercase, we could verify that they were found.

### Validation:
After releasing and deploying, we should verify that these headers are now sent to the ad server.
