### PR TITLE
feat: use JSON log format

### DIFF
--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -1,17 +1,10 @@
 import { createLogger, transports, format } from 'winston';
 
-const logFormat = format.printf(
-  ({ level, message, timestamp, ...metadata }) => {
-    let msg = `${timestamp} [${level}] : ${message} `;
-    if (metadata && Object.keys(metadata).length > 0) {
-      msg += JSON.stringify(metadata);
-    }
-    return msg;
-  }
-);
-
 export default createLogger({
   level: process.env.LOG_LEVEL ? process.env.LOG_LEVEL.toLowerCase() : 'info',
-  format: format.combine(format.colorize(), format.timestamp(), logFormat),
+  format: format.combine(
+    format.timestamp(),
+    format.json()
+  ),
   transports: [new transports.Console()]
 });


### PR DESCRIPTION
The current log format works great when running in a local terminal, but isn't very good when running in the cloud. For example, loki can't parse the current format, making grafana searches a lot harder than they need to be. This PR changes the logging format to JSON to allow metrics and collection systems to parse logs easier.
Signed-off-by: Fredrik Lundkvist <fredrik.lundkvist@eyevinn.se>
