### PR TITLE
feat: better user agent header

### DIFF
--- a/src/encore/encoreclient.test.ts
+++ b/src/encore/encoreclient.test.ts
@@ -62,7 +62,8 @@ describe('EncoreClient', () => {
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/hal+json',
-        'x-jwt': `Bearer ${serviceAccessToken}`
+        'x-jwt': `Bearer ${serviceAccessToken}`,
+        'User-Agent': 'eyevinn/ad-normalizer'
       },
       body: JSON.stringify(job)
     });
@@ -96,7 +97,8 @@ describe('EncoreClient', () => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Accept: 'application/hal+json'
+        Accept: 'application/hal+json',
+        'User-Agent': 'eyevinn/ad-normalizer'
       },
       body: JSON.stringify(job)
     });

--- a/src/encore/encoreclient.ts
+++ b/src/encore/encoreclient.ts
@@ -23,7 +23,11 @@ export class EncoreClient {
       serviceAccessToken ? { 'x-jwt': `Bearer ${serviceAccessToken}` } : {};
     return fetch(`${this.url}/encoreJobs`, {
       method: 'POST',
-      headers: { ...contentHeaders, ...jwtHeader },
+      headers: {
+        ...contentHeaders,
+        ...jwtHeader,
+        'User-Agent': 'eyevinn/ad-normalizer'
+      },
       body: JSON.stringify(job)
     });
   }

--- a/src/vast/vastApi.ts
+++ b/src/vast/vastApi.ts
@@ -319,7 +319,8 @@ const getVastXml = async (
       method: 'GET',
       headers: {
         ...headers,
-        'Content-Type': 'application/xml'
+        'Content-Type': 'application/xml',
+        'User-Agent': 'eyevinn/ad-normalizer'
       }
     });
     if (!response.ok) {

--- a/src/vmap/vmapApi.test.ts
+++ b/src/vmap/vmapApi.test.ts
@@ -685,7 +685,8 @@ describe('VMAP API', () => {
       expect(fetchMock).toHaveBeenCalledWith(expectedUrl, {
         headers: {
           'Content-Type': 'application/xml',
-          'X-Device-User-Agent': 'test-device'
+          'X-Device-User-Agent': 'test-device',
+          'User-Agent': 'eyevinn/ad-normalizer'
         },
         method: 'GET'
       });
@@ -700,7 +701,8 @@ describe('VMAP API', () => {
       expect(fetchMock).toHaveBeenCalledWith(expectedUrl, {
         headers: {
           'Content-Type': 'application/xml',
-          'X-Forwarded-For': 'test-ip'
+          'X-Forwarded-For': 'test-ip',
+          'User-Agent': 'eyevinn/ad-normalizer'
         },
         method: 'GET'
       });

--- a/src/vmap/vmapApi.ts
+++ b/src/vmap/vmapApi.ts
@@ -238,7 +238,11 @@ export const getVmapXml = async (
     logger.info(`Fetching VMAP request from ${url.toString()}`);
     const response = await fetch(url, {
       method: 'GET',
-      headers: { ...headers, 'Content-Type': 'application/xml' }
+      headers: {
+        ...headers,
+        'Content-Type': 'application/xml',
+        'User-Agent': 'eyevinn/ad-normalizer'
+      }
     });
     if (!response.ok) {
       throw new Error('Response from ad server was not OK');


### PR DESCRIPTION
Today, requests from the normalizer have the user agent `node` (default for nodejs); this can cause potential issues with some ad servers, as they might want to block requests from such generic user agents.
This PR sets the User agent header to eyevinn/ad-normalizer in order to mitigate this issue

Signed-off-by: Fredrik Lundkvist <fredrik.lundkvist@eyevinn.se>
