### PR TITLE
feat: support for redis clusters

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -70,7 +70,8 @@ export default (opts: ApiOptions) => {
 
   const redisclient = new RedisClient(
     config.redisUrl,
-    config.packagingQueueName
+    config.packagingQueueName,
+    config.rediscluster
   );
 
   redisclient.connect();

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -9,6 +9,7 @@ describe('config loading behavior', () => {
     process.env.S3_SECRET_KEY = 'secret';
     process.env.AD_SERVER_URL = 'http://adserver.com';
     process.env.REDIS_URL = 'http://redis.com';
+    process.env.REDIS_CLUSTER = 'true';
     process.env.OUTPUT_BUCKET_URL = 's3://ads/';
     process.env.OSC_ACCESS_TOKEN = 'token';
     process.env.KEY_FIELD = 'Url';
@@ -26,6 +27,7 @@ describe('config loading behavior', () => {
     expect(config.encoreUrl).toEqual(expectedEncoreUrl);
     expect(config.keyRegex).toEqual('[a-zA-Z]');
     expect(config.keyField).toEqual('url');
+    expect(config.rediscluster).toEqual(true);
     expect(config.encoreProfile).toEqual('test-profile');
     expect(config.jitPackaging).toEqual(true);
     expect(config.packagingQueueName).toEqual('ad-packaging');

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -10,6 +10,7 @@ export interface AdNormalizerConfiguration {
   bucket: string;
   adServerUrl: string;
   redisUrl: string;
+  rediscluster: boolean;
   oscToken?: string;
   inFlightTtl?: number;
   keyField: string;
@@ -49,6 +50,7 @@ const loadConfiguration = (): AdNormalizerConfiguration => {
     throw new Error('REDIS_URL is required');
   }
   const redisUrl = process.env.REDIS_URL;
+  const redisCluster = process.env.REDIS_CLUSTER === 'true';
   if (!process.env.OUTPUT_BUCKET_URL) {
     throw new Error('OUTPUT_BUCKET_URL is required');
   }
@@ -83,6 +85,7 @@ const loadConfiguration = (): AdNormalizerConfiguration => {
     s3SecretKey: secretKey,
     adServerUrl: adServerUrl,
     redisUrl: redisUrl,
+    rediscluster: redisCluster,
     bucket: removeTrailingSlash(bucketPath),
     oscToken: oscToken,
     inFlightTtl: inFlightTtl ? parseInt(inFlightTtl) : null,

--- a/src/redis/redisclient.ts
+++ b/src/redis/redisclient.ts
@@ -34,11 +34,9 @@ export class RedisClient {
 
   async connect() {
     if (this.clusterMode) {
-      logger.info('Client is in cluster mode');
       await this.connectCluster();
       return;
     }
-    logger.info('Client is in standalone mode');
     if (this.client != null) {
       logger.info('Redis client already connected');
       return;

--- a/src/redis/redisclient.ts
+++ b/src/redis/redisclient.ts
@@ -15,7 +15,7 @@ export class RedisClient {
   ) {}
 
   async connectCluster() {
-    console.log('Connecting to Redis cluster');
+    logger.info('Connecting to Redis cluster', { url: this.url });
     if (this.cluster != null) {
       logger.info('Redis cluster already connected');
       return;
@@ -34,9 +34,11 @@ export class RedisClient {
 
   async connect() {
     if (this.clusterMode) {
+      logger.info('Client is in cluster mode');
       await this.connectCluster();
       return;
     }
+    logger.info('Client is in standalone mode');
     if (this.client != null) {
       logger.info('Redis client already connected');
       return;

--- a/src/redis/redisclient.ts
+++ b/src/redis/redisclient.ts
@@ -1,4 +1,4 @@
-import { createClient } from 'redis';
+import { createClient, createCluster } from 'redis';
 import logger from '../util/logger';
 import { TranscodeInfo } from '../data/transcodeinfo';
 
@@ -7,9 +7,36 @@ export const DEFAULT_TTL = 1800; // TTL of 30 minutes to account for queue time
 
 export class RedisClient {
   private client: Awaited<ReturnType<typeof createClient>> | null = null;
-  constructor(private url: string, private packagingQueueName?: string) {}
+  private cluster: Awaited<ReturnType<typeof createCluster>> | null = null;
+  constructor(
+    private url: string,
+    private packagingQueueName?: string,
+    private clusterMode: boolean = false
+  ) {}
+
+  async connectCluster() {
+    console.log('Connecting to Redis cluster');
+    if (this.cluster != null) {
+      logger.info('Redis cluster already connected');
+      return;
+    }
+    logger.info('Connecting to Redis cluster', { url: this.url });
+    let urls = this.url.split(',');
+    let rootNodes = urls.map((url) => {
+      return { url: url };
+    });
+    this.cluster = createCluster({
+      rootNodes: rootNodes
+    }).on('error', (err) => logger.error('Redis cluster error:', err));
+    await this.cluster.connect();
+    return;
+  }
 
   async connect() {
+    if (this.clusterMode) {
+      await this.connectCluster();
+      return;
+    }
     if (this.client != null) {
       logger.info('Redis client already connected');
       return;
@@ -34,11 +61,11 @@ export class RedisClient {
 
   async get(key: string): Promise<string | null | undefined> {
     await this.connect();
-    if (this?.client == null) {
+    if (this?.client == null && this?.cluster == null) {
       logger.error('Redis client not connected');
     }
     logger.info('Getting key', { key });
-    return this.client?.get(key);
+    return this.clusterMode ? this.cluster?.get(key) : this.client?.get(key);
   }
 
   async getTranscodeStatus(key: string): Promise<TranscodeInfo | null> {
@@ -53,14 +80,18 @@ export class RedisClient {
   async set(key: string, value: string, ttl: number): Promise<void> {
     logger.info('Setting key', { key, value });
     await this.connect();
-    this.client?.set(key, value);
+    this.clusterMode
+      ? this.cluster?.set(key, value)
+      : this.client?.set(key, value);
     await this.setTtl(key, ttl);
   }
 
   async setTtl(key: string, ttl: number): Promise<void> {
     if (ttl > 0) {
       logger.info('Setting key expiration', { key, ttl });
-      await this.client?.expire(key, ttl);
+      this.clusterMode
+        ? await this.cluster?.expire(key, ttl)
+        : await this.client?.expire(key, ttl);
     } else {
       const expireTime = await this.client?.expireTime(key);
       if (expireTime != undefined) {
@@ -72,7 +103,9 @@ export class RedisClient {
             logger.error('Key does not exist', { key });
             break;
           default:
-            await this.client?.persist(key);
+            this.clusterMode
+              ? await this.cluster?.persist(key)
+              : await this.client?.persist(key);
         }
       }
     }

--- a/src/redis/redisclient.ts
+++ b/src/redis/redisclient.ts
@@ -21,8 +21,8 @@ export class RedisClient {
       return;
     }
     logger.info('Connecting to Redis cluster', { url: this.url });
-    let urls = this.url.split(',');
-    let rootNodes = urls.map((url) => {
+    const urls = this.url.split(',');
+    const rootNodes = urls.map((url) => {
       return { url: url };
     });
     this.cluster = createCluster({


### PR DESCRIPTION
- **feat: experimental redis cluster support**
## Motivation
To improve scalability and robustness, it is advisable to run redis/valkey in cluster mode with sharding; setting this up in the redis library is different from standalone mode. This PR adds support for conencting to redis clusters.

## The fix
This PR adds the boolean field `clusterMode` to the Redis client class. This flag is controlled by the configuration (set the `REDIS_CLUSTER` env var to `true`).
If the client is in cluster mode, it will do all redis operations in a cluster-compatible way.
