### PR TITLE
feat: support subdomains on ad server

### DIFF
--- a/src/util/string.test.ts
+++ b/src/util/string.test.ts
@@ -1,4 +1,4 @@
-import { createPackageUrl } from './string';
+import { createPackageUrl, replaceSubDomain } from './string';
 
 describe('string utils', () => {
   it('can create a package url with asset server url', () => {
@@ -20,5 +20,12 @@ describe('string utils', () => {
     expect(createPackageUrl(assetServerUrl, outputFolder, baseName)).toEqual(
       expectedUrl
     );
+  });
+
+  it('can replace subdomain', () => {
+    const url = new URL('http://old-subdomain.example.com/path');
+    const newSubDomain = 'new-subdomain';
+    const expectedUrl = 'http://new-subdomain.example.com/path';
+    expect(replaceSubDomain(url, newSubDomain).href).toEqual(expectedUrl);
   });
 });

--- a/src/util/string.ts
+++ b/src/util/string.ts
@@ -26,3 +26,14 @@ export const createOutputUrl = (bucket: URL, folder: string): string | null => {
     return null;
   }
 };
+
+export const replaceSubDomain = (url: URL, newSubDomain: string): URL => {
+  const hostParts = url.hostname.split('.');
+  if (hostParts.length > 2) {
+    hostParts[0] = newSubDomain;
+    url.hostname = hostParts.join('.');
+  } else {
+    url.hostname = newSubDomain + '.' + url.hostname;
+  }
+  return url;
+};

--- a/src/vast/vastApi.ts
+++ b/src/vast/vastApi.ts
@@ -7,6 +7,7 @@ import { timestampToSeconds } from '../util/time';
 import { TranscodeInfo, TranscodeStatus } from '../data/transcodeinfo';
 import { EncoreService } from '../encore/encoreservice';
 import { getHeaderValue } from '../util/headers';
+import { replaceSubDomain } from '../util/string';
 
 export const deviceUserAgentHeader = 'X-Device-User-Agent';
 
@@ -309,10 +310,14 @@ const getVastXml = async (
   headers: Record<string, string> = {}
 ): Promise<string> => {
   try {
-    const url = new URL(adServerUrl);
+    let url = new URL(adServerUrl);
     const params = new URLSearchParams(path.split('?')[1]);
     for (const [key, value] of params) {
-      url.searchParams.append(key, value);
+      if (key == 'subDomain') {
+        url = replaceSubDomain(url, value);
+      } else {
+        url.searchParams.append(key, value);
+      }
     }
     logger.info(`Fetching VAST request from ${url.toString()}`);
     const response = await fetch(url, {

--- a/src/vmap/vmapApi.test.ts
+++ b/src/vmap/vmapApi.test.ts
@@ -676,10 +676,34 @@ describe('VMAP API', () => {
       ) as jest.Mock
     );
     it('should pass along user device header', async () => {
-      getVmapXml('http://ad-server-url/api', '/path/to/vmap?param=value', {
-        [deviceUserAgentHeader]: 'test-device'
+      getVmapXml(
+        'http://domain1.ad-server-url/api',
+        '/path/to/vmap?param=value&subDomain=domain2',
+        {
+          [deviceUserAgentHeader]: 'test-device'
+        }
+      );
+      const expectedUrl = new URL('http://domain1.ad-server-url/api');
+      expectedUrl.searchParams.append('param', 'value');
+      expectedUrl.searchParams.append('rt', 'vmap');
+      expect(fetchMock).toHaveBeenCalledWith(expectedUrl, {
+        headers: {
+          'Content-Type': 'application/xml',
+          'X-Device-User-Agent': 'test-device',
+          'User-Agent': 'eyevinn/ad-normalizer'
+        },
+        method: 'GET'
       });
-      const expectedUrl = new URL('http://ad-server-url/api');
+    });
+    it('should replace subdomain if provided', async () => {
+      getVmapXml(
+        'http://domain1.ad-server-url/api',
+        '/path/to/vmap?param=value&subDomain=domain2',
+        {
+          [deviceUserAgentHeader]: 'test-device'
+        }
+      );
+      const expectedUrl = new URL('http://domain2.ad-server-url/api');
       expectedUrl.searchParams.append('param', 'value');
       expectedUrl.searchParams.append('rt', 'vmap');
       expect(fetchMock).toHaveBeenCalledWith(expectedUrl, {

--- a/src/vmap/vmapApi.ts
+++ b/src/vmap/vmapApi.ts
@@ -16,6 +16,7 @@ import {
 import logger from '../util/logger';
 import { TranscodeInfo, TranscodeStatus } from '../data/transcodeinfo';
 import { getHeaderValue } from '../util/headers';
+import { replaceSubDomain } from '../util/string';
 
 interface VmapAdBreak {
   '@_breakId'?: string;
@@ -230,10 +231,14 @@ export const getVmapXml = async (
   headers: Record<string, string> = {}
 ): Promise<string> => {
   try {
-    const url = new URL(adServerUrl);
+    let url = new URL(adServerUrl);
     const params = new URLSearchParams(path.split('?')[1]);
     for (const [key, value] of params) {
-      url.searchParams.append(key, value);
+      if (key == 'subDomain') {
+        url = replaceSubDomain(url, value);
+      } else {
+        url.searchParams.append(key, value);
+      }
     }
     logger.info(`Fetching VMAP request from ${url.toString()}`);
     const response = await fetch(url, {


### PR DESCRIPTION
Adds support for cases where the caller may want to call a specific sub-domain on the ad server, f.ex. when a provider has multiple brands, or used by an aggregator provider.

Closes #55
Signed-off-by: Fredrik Lundkvist <fredrik.lundkvist@eyevinn.se>
