### PR TITLE
feat: use UUID subfolders to avoid problems with eventual consistency

### DIFF
--- a/src/util/string.ts
+++ b/src/util/string.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { default as PathUtils } from 'path';
 
 export const removeTrailingSlash = (url: string): string => {
@@ -21,7 +22,7 @@ export const createPackageUrl = (
 
 export const createOutputUrl = (bucket: URL, folder: string): string | null => {
   try {
-    return new URL(PathUtils.join(bucket.pathname, folder), bucket).href + '/';
+    return new URL(PathUtils.join(bucket.pathname, randomUUID(), folder), bucket).href + '/';
   } catch (e) {
     return null;
   }

--- a/src/util/string.ts
+++ b/src/util/string.ts
@@ -22,7 +22,10 @@ export const createPackageUrl = (
 
 export const createOutputUrl = (bucket: URL, folder: string): string | null => {
   try {
-    return new URL(PathUtils.join(bucket.pathname, randomUUID(), folder), bucket).href + '/';
+    return (
+      new URL(PathUtils.join(bucket.pathname, folder, randomUUID()), bucket)
+        .href + '/'
+    );
   } catch (e) {
     return null;
   }

--- a/src/util/utils.test.ts
+++ b/src/util/utils.test.ts
@@ -1,9 +1,15 @@
+const crypto = require('crypto');
 import { calculateAspectRatio } from './aspectratio';
 import { getHeaderValue } from './headers';
 import { createOutputUrl, createPackageUrl } from './string';
 import { timestampToSeconds } from './time';
 
 describe('time utils', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(crypto, 'randomUUID')
+      .mockReturnValue('00000000-0000-0000-0000-000000000000');
+  });
   it('deserializes timestamps correctly', () => {
     let timestamp = '00:00:15';
     let parsed = timestampToSeconds(timestamp);
@@ -58,9 +64,11 @@ describe('string utils', () => {
     expect(actual).toBe(expected);
   });
   it('constructs an output url correctly', () => {
+    const uuid = crypto.randomUUID();
+
     const bucket = new URL('s3://test-bucket.osaas.io');
     const folder = 'test-folder';
-    const expected = 's3://test-bucket.osaas.io/test-folder/';
+    const expected = 's3://test-bucket.osaas.io/' + uuid + '/test-folder/';
     const actual = createOutputUrl(bucket, folder);
     expect(actual).toBe(expected);
   });

--- a/src/util/utils.test.ts
+++ b/src/util/utils.test.ts
@@ -1,4 +1,5 @@
-const crypto = require('crypto');
+// eslint-disable-next-line
+const crypto = require('crypto'); // required to do it this way for jest to mock it
 import { calculateAspectRatio } from './aspectratio';
 import { getHeaderValue } from './headers';
 import { createOutputUrl, createPackageUrl } from './string';
@@ -68,7 +69,7 @@ describe('string utils', () => {
 
     const bucket = new URL('s3://test-bucket.osaas.io');
     const folder = 'test-folder';
-    const expected = 's3://test-bucket.osaas.io/' + uuid + '/test-folder/';
+    const expected = 's3://test-bucket.osaas.io/test-folder/' + uuid + '/';
     const actual = createOutputUrl(bucket, folder);
     expect(actual).toBe(expected);
   });


### PR DESCRIPTION
## Motivation
With the way the normalizer currently works, there's a risk of running into issues with eventual consistency if content is re-encoded (f.ex. when the valkey is cleared due to a change in transcoding profiles).
If the same key already exists on the object storage, it _should_ be overwritten before the packager fetches the transcoded files, but depending on consistency guarantees, there _could_ be cases where an old transcoding output is packaged. This PR aims to solve that potential issue.

## The fix
When constructing the output folder path, the normalizer appends a UUID to the folder structure. This ensures that each new transcode gets a separate output folder, eliminating overwrites and making sure we avoid issues with eventual consistency.


### Commits
- **feat: use uuid subfolders to avoid problems with eventual consistency on s3**
- **fix: correct folder order**
