### PR TITLE
chore: more detailed traces

### DIFF
--- a/src/vast/vastApi.ts
+++ b/src/vast/vastApi.ts
@@ -186,9 +186,9 @@ export const vastApi: FastifyPluginCallback<AdApiOptions> = (
       }
       const response = await trace
         .getTracerProvider()
-        .getTracer('GET /api/v1/vast')
+        .getTracer('/api/v1/vast')
         .startActiveSpan('VAST API Request', async (span: Span) => {
-          span.addEvent('Fetching VAST request from ad server');
+          span.addEvent('Fetching VAST from ad server');
 
           const vastStr = await getVastXml(
             opts.adServerUrl,
@@ -196,7 +196,7 @@ export const vastApi: FastifyPluginCallback<AdApiOptions> = (
             vastReqHeaders
           );
 
-          span.addEvent('Fetched VAST request from ad server');
+          span.addEvent('Fetched VAST from ad server');
           span.addEvent('Parsing VAST XML');
 
           const vastXml = parseVast(vastStr);
@@ -400,7 +400,7 @@ const replaceMediaFiles = (
     const parser = new XMLParser({ ignoreAttributes: false, isArray: isArray });
     const built = trace
       .getTracerProvider()
-      .getTracer('vastApi')
+      .getTracer('/api/v1/vast')
       .startActiveSpan('Replace Media Files in VAST', (span: Span) => {
         span.addEvent('Parsing VAST XML for media file replacement');
 

--- a/src/vast/vastApi.ts
+++ b/src/vast/vastApi.ts
@@ -185,6 +185,13 @@ export const vastApi: FastifyPluginCallback<AdApiOptions> = (
         vastReqHeaders = { ...vastReqHeaders, 'X-Forwarded-For': forwardedFor };
       }
       let span = trace.getActiveSpan();
+      if (!span) {
+        logger.debug('No active span found, creating a new one');
+        span = trace
+          .getTracerProvider()
+          .getTracer('vastApi')
+          .startSpan('VAST API Request');
+      }
       if (span) {
         span.addEvent('Fetching VAST request from ad server');
       }

--- a/src/vast/vastApi.ts
+++ b/src/vast/vastApi.ts
@@ -186,32 +186,27 @@ export const vastApi: FastifyPluginCallback<AdApiOptions> = (
       }
       const span = trace
         .getTracerProvider()
-        .getTracer('vastApi')
+        .getTracer('GET /api/v1/vast')
         .startSpan('VAST API Request');
-      if (!span) {
-        logger.debug('No active span found, creating a new one');
-      }
-      if (span) {
-        span.addEvent('Fetching VAST request from ad server');
-      }
+      span.addEvent('Fetching VAST request from ad server');
+
       const vastStr = await getVastXml(opts.adServerUrl, path, vastReqHeaders);
-      if (span) {
-        span.addEvent('Fetched VAST request from ad server');
-        span.addEvent('Parsing VAST XML');
-      }
+
+      span.addEvent('Fetched VAST request from ad server');
+      span.addEvent('Parsing VAST XML');
+
       const vastXml = parseVast(vastStr);
-      if (span) {
-        span.addEvent('Parsed VAST XML successfully');
-      }
+      span.addEvent('Parsed VAST XML successfully');
+
       const response = await findMissingAndDispatchJobs(vastXml, opts);
-      if (span) {
-        span.addEvent('Found missing assets and dispatched jobs');
-        span.addEvent('Preparing response');
-      }
+
+      span.addEvent('Found missing assets and dispatched jobs');
+      span.addEvent('Preparing response');
+
       reply.send(response);
-      if (span) {
-        span.addEvent('Response prepared successfully');
-      }
+      span.addEvent('Response prepared successfully');
+      span.end;
+
       return reply;
     }
   );
@@ -403,17 +398,14 @@ const replaceMediaFiles = (
       .getTracerProvider()
       .getTracer('vastApi')
       .startSpan('VAST API Request');
-    if (span) {
-      span.addEvent('Parsing VAST XML for media file replacement');
-    }
+    span.addEvent('Parsing VAST XML for media file replacement');
+
     const parsedVAST = parser.parse(vastXml);
-    if (span) {
-      span.addEvent('Parsed VAST XML successfully');
-    }
+    span.addEvent('Parsed VAST XML successfully');
+
     if (parsedVAST.VAST.Ad) {
-      if (span) {
-        span.addEvent('Replacing media files in VAST Ad');
-      }
+      span.addEvent('Replacing media files in VAST Ad');
+
       const vastAds = Array.isArray(parsedVAST.VAST.Ad)
         ? parsedVAST.VAST.Ad
         : [parsedVAST.VAST.Ad];
@@ -431,14 +423,12 @@ const replaceMediaFiles = (
         }
         return acc;
       }, []);
-      if (span) {
-        span.addEvent('Replaced media files in VAST Ad');
-      }
+      span.addEvent('Replaced media files in VAST Ad');
     }
-    if (span) {
-      span.addEvent('Building XML from modified VAST');
-    }
+    span.addEvent('Building XML from modified VAST');
+
     const builder = new XMLBuilder({ format: true, ignoreAttributes: false });
+    span.end();
     return builder.build(parsedVAST);
   } catch (error) {
     logger.error('Failed to replace media files in VAST', error);

--- a/src/vast/vastApi.ts
+++ b/src/vast/vastApi.ts
@@ -184,13 +184,12 @@ export const vastApi: FastifyPluginCallback<AdApiOptions> = (
       if (forwardedFor) {
         vastReqHeaders = { ...vastReqHeaders, 'X-Forwarded-For': forwardedFor };
       }
-      let span = trace.getActiveSpan();
+      const span = trace
+        .getTracerProvider()
+        .getTracer('vastApi')
+        .startSpan('VAST API Request');
       if (!span) {
         logger.debug('No active span found, creating a new one');
-        span = trace
-          .getTracerProvider()
-          .getTracer('vastApi')
-          .startSpan('VAST API Request');
       }
       if (span) {
         span.addEvent('Fetching VAST request from ad server');
@@ -400,7 +399,10 @@ const replaceMediaFiles = (
 ): string => {
   try {
     const parser = new XMLParser({ ignoreAttributes: false, isArray: isArray });
-    let span = trace.getActiveSpan();
+    const span = trace
+      .getTracerProvider()
+      .getTracer('vastApi')
+      .startSpan('VAST API Request');
     if (span) {
       span.addEvent('Parsing VAST XML for media file replacement');
     }


### PR DESCRIPTION
## Summary
This PR improves tracing granularity by enveloping vast and vmap api endpoints within trace spans; by doing this, we create better and more detailed traces that are more useful for identifying latency issues.
It's been used with a customer to identify the cause of timeouts when fetching ad data in live scenarios.
### commits:
- **chore: add span events to VAST endpoint**
- **chore: more events**
- **fix: start span if one doesn't alreayd exist**
- **fix: just start new spans**
- **fix: no need for clauses**
- **fix: set span as active**
- **fix: deeper span**
- **chore: add span events to vmap endpoint**
