### PR TITLE
build: add procps-ng for healthcheck purposes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN adduser \
 RUN apk add --no-cache tzdata
 ## Needed if downstream users want to export metrics to f.ex. cloudwatch
 RUN apk update 
-RUN apk add curl tar procps
+RUN apk add curl tar procps-ng
 
 WORKDIR $GOPATH/src/smallest-golang/app/
 


### PR DESCRIPTION
Add procps-ng to allow for pgrep. This lets users run pgrep to health check the process in their deployments.

- **build: add procps to docker image**
- **build: switch to procps-ng**
