### PR TITLE
fix: make subdomain detection case-insensitive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Eyevinn/ad-normalizer
 go 1.24.2
 
 require (
-	github.com/Eyevinn/VMAP v0.3.1
+	github.com/Eyevinn/VMAP v0.3.2
 	github.com/EyevinnOSC/client-go v0.0.4
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/CarlLindqvist/xmltokenizer v0.0.10 h1:pdp+yJZTOijVnGR6oeuqecXY9zIt7O2
 github.com/CarlLindqvist/xmltokenizer v0.0.10/go.mod h1:OlBoGMMzCOY2cnz7NLSuBQjlVRYYbarlqbFelQf14XM=
 github.com/Eyevinn/VMAP v0.3.1 h1:s+BfCFJDCGeeUePRliW7oAgJf5MNBLhFAId7QlIQ1ls=
 github.com/Eyevinn/VMAP v0.3.1/go.mod h1:5n80N+ssgJzWJW6wb74c/Ayzo1pLRwMOptYmZ1TIThk=
+github.com/Eyevinn/VMAP v0.3.2 h1:p7pDZYmSIiW1Q79QLFo/iDhq02RCi8r5IBLP/YqEapk=
+github.com/Eyevinn/VMAP v0.3.2/go.mod h1:5n80N+ssgJzWJW6wb74c/Ayzo1pLRwMOptYmZ1TIThk=
 github.com/EyevinnOSC/client-go v0.0.4 h1:4iZr7nAGJrL1dqka9rybyzESxQiLrv0rhZF+XBWw310=
 github.com/EyevinnOSC/client-go v0.0.4/go.mod h1:Y20c9F5BO3cdFToVxVUAb9+lRhilDmbnPVyOksLhnrI=
 github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=

--- a/internal/serve/api.go
+++ b/internal/serve/api.go
@@ -167,7 +167,13 @@ func (api *API) makeAdServerRequest(r *http.Request, ctx context.Context) ([]byt
 	_, span := otel.Tracer("api").Start(ctx, "makeAdServerRequest")
 	defer span.End()
 	newUrl := api.adServerUrl
-	if subdomain := r.URL.Query().Get("subdomain"); subdomain != "" {
+	subdomain := ""
+	for k := range r.URL.Query() {
+		if strings.ToLower(k) == "subdomain" {
+			subdomain = r.URL.Query().Get(k)
+		}
+	}
+	if subdomain != "" {
 		logger.Debug("Replacing subdomain in URL",
 			slog.String("subdomain", subdomain),
 			slog.String("originalUrl", newUrl.String()),

--- a/internal/serve/api_test.go
+++ b/internal/serve/api_test.go
@@ -161,7 +161,12 @@ func TestReplaceVast(t *testing.T) {
 	vastReq.Header.Set("accept", "application/xml")
 	// make sure we request a VAST response
 	qps := vastReq.URL.Query()
+	newUrl := strings.Replace(testServer.URL, "127", "128", 1)
+	parsedUrl, err := url.Parse(newUrl)
+	is.NoErr(err)
+	api.adServerUrl = *parsedUrl
 	qps.Set("requestType", "vast")
+	qps.Set("subDomain", "127")
 	vastReq.URL.RawQuery = qps.Encode()
 	recorder := httptest.NewRecorder()
 	api.HandleVast(recorder, vastReq)
@@ -179,6 +184,9 @@ func TestReplaceVast(t *testing.T) {
 	is.Equal(mediaFile.Text, "https://testcontent.eyevinn.technology/ads/alvedon-10s.m3u8")
 	is.Equal(mediaFile.Width, 718)
 	is.Equal(mediaFile.Height, 404)
+
+	realUrl, _ := url.Parse(testServer.URL)
+	api.adServerUrl = *realUrl // Reset to original URL
 
 	encoreHandler.reset()
 	storeStub.reset()


### PR DESCRIPTION
Fixes a bug caused by the detection of the query param `subdomain` being case-sensitive, leading to incorrect ad server requests.
Bumps @eyevinn/VMAP dependency to v0.3.2, fixing decoding errors when receiving empty VAST inside a VMAP.
