### PR TITLE
feat(serve): skip transcode completion if encore job has no audio output

### DIFF
--- a/internal/serve/api_test.go
+++ b/internal/serve/api_test.go
@@ -140,6 +140,15 @@ func (e *EncoreHandlerStub) GetEncoreJob(jobId string) (structure.EncoreJob, err
 					},
 				},
 			},
+			{
+				MediaType: "Audio",
+				AudioStreams: []structure.EncoreAudioStream{
+					{
+						Codec:    "AAC",
+						Channels: 2,
+					},
+				},
+			},
 		},
 		Inputs: []structure.EncoreInput{
 			{

--- a/internal/serve/encore.go
+++ b/internal/serve/encore.go
@@ -88,6 +88,14 @@ func (api *API) handleTranscodeCompleted(progress *structure.EncoreJobProgress) 
 		)
 		return err
 	}
+	if !job.HasAudioOutput() {
+		logger.Error("encore job has no audio output, skipping",
+			slog.String("jobId", progress.JobId),
+			slog.String("creativeId", progress.ExternalId),
+		)
+		_ = api.valkeyStore.Delete(progress.ExternalId)
+		return nil
+	}
 	transcodeInfo, err := structure.TranscodeInfoFromEncoreJob(&job, api.jitPackage, api.assetServerUrl)
 	if err != nil {
 		logger.Error("failed to create transcode info from encore job",

--- a/internal/structure/encore.go
+++ b/internal/structure/encore.go
@@ -31,6 +31,15 @@ func (ep *EncoreJob) GetFrameRates() []float64 {
 	return slices.Compact(framerates)
 }
 
+func (ep *EncoreJob) HasAudioOutput() bool {
+	for _, o := range ep.Outputs {
+		if len(o.AudioStreams) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 type EncoreInput struct {
 	Uri       string  `json:"uri"`
 	SeekTo    float64 `json:"seekTo,omitempty"`

--- a/internal/structure/encore_test.go
+++ b/internal/structure/encore_test.go
@@ -6,6 +6,48 @@ import (
 	"github.com/matryer/is"
 )
 
+
+func TestHasAudioOutput(t *testing.T) {
+	is := is.New(t)
+
+	t.Run("no outputs", func(t *testing.T) {
+		is := is.New(t)
+		ej := EncoreJob{}
+		is.Equal(ej.HasAudioOutput(), false)
+	})
+
+	t.Run("outputs without audio streams", func(t *testing.T) {
+		is := is.New(t)
+		ej := EncoreJob{
+			Outputs: []EncoreOutput{
+				{VideoStreams: []EncoreVideoStream{{Codec: "h264"}}},
+			},
+		}
+		is.Equal(ej.HasAudioOutput(), false)
+	})
+
+	t.Run("output with audio stream", func(t *testing.T) {
+		is := is.New(t)
+		ej := EncoreJob{
+			Outputs: []EncoreOutput{
+				{AudioStreams: []EncoreAudioStream{{Codec: "aac"}}},
+			},
+		}
+		is.Equal(ej.HasAudioOutput(), true)
+	})
+
+	t.Run("mixed outputs, one has audio", func(t *testing.T) {
+		is := is.New(t)
+		ej := EncoreJob{
+			Outputs: []EncoreOutput{
+				{VideoStreams: []EncoreVideoStream{{Codec: "h264"}}},
+				{AudioStreams: []EncoreAudioStream{{Codec: "aac"}}},
+			},
+		}
+		is.Equal(ej.HasAudioOutput(), true)
+	})
+}
+
 func TestGetFrameRates(t *testing.T) {
 	is := is.New(t)
 	ej := EncoreJob{


### PR DESCRIPTION
## Summary
- Added a guard in `handleTranscodeCompleted` that checks for at least one audio stream using `HasAudioOutput()` before creating a `TranscodeInfo`
- If no audio output is present, the job is removed from the store and processing is skipped
- Updated `EncoreHandlerStub` in tests to include an audio output stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)