### PR TITLE
chore: bump github.com/Eyevinn/VMAP to v0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Eyevinn/ad-normalizer
 go 1.26.0
 
 require (
-	github.com/Eyevinn/VMAP v0.3.3
+	github.com/Eyevinn/VMAP v0.4.0
 	github.com/EyevinnOSC/client-go v0.0.4
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/CarlLindqvist/xmltokenizer v0.0.10 h1:pdp+yJZTOijVnGR6oeuqecXY9zIt7O2
 github.com/CarlLindqvist/xmltokenizer v0.0.10/go.mod h1:OlBoGMMzCOY2cnz7NLSuBQjlVRYYbarlqbFelQf14XM=
 github.com/Eyevinn/VMAP v0.3.3 h1:QMEe75gH4H9DAsucqb/keUSkMNAEid1hHPNJ25iikqE=
 github.com/Eyevinn/VMAP v0.3.3/go.mod h1:5n80N+ssgJzWJW6wb74c/Ayzo1pLRwMOptYmZ1TIThk=
+github.com/Eyevinn/VMAP v0.4.0 h1:+3PK3af5NDdmXPyqXVnf07jjnSxUXo3iYtZkPsPHSF0=
+github.com/Eyevinn/VMAP v0.4.0/go.mod h1:5n80N+ssgJzWJW6wb74c/Ayzo1pLRwMOptYmZ1TIThk=
 github.com/EyevinnOSC/client-go v0.0.4 h1:4iZr7nAGJrL1dqka9rybyzESxQiLrv0rhZF+XBWw310=
 github.com/EyevinnOSC/client-go v0.0.4/go.mod h1:Y20c9F5BO3cdFToVxVUAb9+lRhilDmbnPVyOksLhnrI=
 github.com/alicebob/miniredis/v2 v2.35.0 h1:QwLphYqCEAo1eu1TqPRN2jgVMPBweeQcR21jeqDCONI=


### PR DESCRIPTION
## Summary

- Bumps `github.com/Eyevinn/VMAP` from `v0.3.3` to `v0.4.0`
- v0.4.0 adds two new opt-in APIs: `DecodeVmapScan`/`DecodeVastScan` (a faster byte-scanning decoder) and `MarshalVmap`/`MarshalVast` (a fast encoder); no existing API was changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)